### PR TITLE
Fix py2/py3 error with dict.keys

### DIFF
--- a/sql_grader/models.py
+++ b/sql_grader/models.py
@@ -192,7 +192,7 @@ class XBlockDataMixin:
         help=_('Which initial dataset/database to be used for queries'),
         default='rating',
         scope=Scope.content,
-        values=DATABASES.keys(),
+        values=list(DATABASES),
     )
     answer_query = String(
         display_name=_('Answer Query'),


### PR DESCRIPTION
This approach works in both Python2 and Python3, whereas the original
implementation only worked in the former [1].

* References:
- [1] https://stackoverflow.com/questions/17322668/typeerror-dict-keys-object-does-not-support-indexing#comment39878944_17322707
- [2] TNL-7169