### PR TITLE
[SE-3220] Add support for multiple statements in the XBlock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """
 Setup the XBlock
 """
-from setuptools import setup
+from setuptools import setup, find_packages
 import os
 
 
@@ -14,6 +14,7 @@ def package_data(pkg, roots):
     """
     data = []
     for root in roots:
+        data.append(root)
         for dirname, _, files in os.walk(os.path.join(pkg, root)):
             for fname in files:
                 data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
@@ -47,12 +48,10 @@ def is_requirement(line):
 
 setup(
     name='xblock-sql-grader',
-    version='0.1',
+    version='0.2',
     description='SQL Grader XBlock',  # TODO: write a better description.
     license='AGPLv3',
-    packages=[
-        'sql_grader',
-    ],
+    packages=find_packages(exclude=('sql_grader.tests')),
     install_requires=load_requirements('requirements/base.in'),
     entry_points={
         'xblock.v1': [

--- a/sql_grader/mixins/grading.py
+++ b/sql_grader/mixins/grading.py
@@ -26,8 +26,9 @@ from ..problem import all_datasets
 log = logging.getLogger('sql_grader')
 
 
-# pylint: disable=unused-argument
-def attempt_safe(dataset, answer_query, verify_query, is_ordered, query):
+# pylint: disable=too-many-arguments
+def attempt_safe(dataset, answer_query, verify_query, modification_query,
+                 is_ordered, query):
     """
     Attempt a SqlProblem, using codejail to sandbox the execution.
     """
@@ -35,6 +36,7 @@ def attempt_safe(dataset, answer_query, verify_query, is_ordered, query):
         'answer_query': answer_query,
         'dataset': dataset,
         'verify_query': verify_query,
+        'modification_query': modification_query,
         'is_ordered': is_ordered,
         'query': query
     }
@@ -44,6 +46,7 @@ submission_result, answer_result, error, comparison = SqlProblem(
     answer_query=answer_query,
     dataset=dataset,
     verify_query=verify_query,
+    modification_query=modification_query,
     is_ordered=is_ordered
 ).attempt(query)
 
@@ -145,6 +148,7 @@ class Scorable(ScorableXBlockMixin):
             self.dataset,
             self.answer_query,
             self.verify_query,
+            self.modification_query,
             self.is_ordered,
             self.raw_response
         )
@@ -188,6 +192,18 @@ class XBlockDataMixin:
         help=_(
             'A secondary verification SQL query, to be used if the '
             'answer_query modifies the database (UPDATE, INSERT, DELETE, etc.)'
+            '. Only enter a single SELECT query here, which is used for '
+            'matching the answer'
+        ),
+        default='',
+        scope=Scope.content,
+        multiline_editor=True,
+    )
+    modification_query = String(
+        display_name=_('Modification query statements'),
+        help=_(
+            'Optional SQL statements, to be executed after the '
+            'user-submitted query, but before the verify_query.'
         ),
         default='',
         scope=Scope.content,
@@ -204,6 +220,7 @@ class XBlockDataMixin:
         'dataset',
         'display_name',
         'verify_query',
+        'modification_query',
         'is_ordered',
         'prompt',
         'weight',
@@ -240,5 +257,6 @@ class XBlockDataMixin:
             'error_class': error_class,
             'raw_response': self.raw_response,
             'verify_query': self.verify_query,
+            'modification_query': self.modification_query,
         })
         return context

--- a/sql_grader/templates/view.html
+++ b/sql_grader/templates/view.html
@@ -61,6 +61,11 @@
         {% if verify_query %}
         <div class="sql_verify_query">
           {% trans 'To check your data modification statement, we ran the following query after your modification:' %}
+          {% if modification_query %}
+          <pre>
+            {{ modification_query }}
+          </pre>
+          {% endif %}
           <pre>
             {{ verify_query }}
           </pre>

--- a/sql_grader/tests/test_problem.py
+++ b/sql_grader/tests/test_problem.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+"""
+Test basic XBlock display function
+"""
+import os
+
+from unittest import TestCase
+
+from sql_grader.problem import SqlProblem
+
+
+class TestGrading(TestCase):
+    """
+    Test grading of different types of problems
+    """
+    def setUp(self):
+        current_folder = os.path.dirname(__file__)
+        sql_file = "{0}/../datasets/rating.sql".format(current_folder)
+        self.database = SqlProblem.create_database(sql_file)
+
+    def test_select_returning_matching_results_in_wrong_order(self):
+        """
+        In a problem which is set up to be order-sensitive, test that a SELECT
+        statement that returns the expected set of results but in the wrong
+        order won't be accepted as matching the answer.
+        """
+        answer_query = "SELECT * FROM Movie order by mID desc;"
+        query = "SELECT * FROM Movie order by mID asc;"
+        submission_result, answer_result, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=None,
+            is_ordered=True
+        ).attempt(query)
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, False)
+        self.assertEqual(submission_result, sorted(answer_result))
+
+    def test_select_returning_matching_results_in_unordered_problem(self):
+        """
+        In a problem which isn't order-sensitive, test that a SELECT
+        statement that returns the expected set of results is accepted.
+        """
+        answer_query = "SELECT * FROM Movie order by mID desc;"
+        query = "SELECT * FROM Movie order by mID asc;"
+        submission_result, answer_result, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=None,
+            is_ordered=False
+        ).attempt(query)
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, True)
+        self.assertEqual(submission_result, sorted(answer_result))
+        self.assertNotEqual(submission_result, answer_result)
+
+    def test_select_with_different_rows_returned(self):
+        """
+        Test that a SELECT that returns different rows to the expected rows
+        isn't considered as matching the answer.
+        """
+        answer_query = "SELECT * FROM Movie order by mID desc;"
+        query = "select * from Movie where mID=101"
+        _, _, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=None,
+            is_ordered=False
+        ).attempt(query)
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, False)
+
+    def test_select_with_different_columns_returned(self):
+        """
+        Test that a SELECT that returns different columns that don't match the
+        columns in the answer isn't considered as matching the answer.
+        """
+        answer_query = "SELECT * FROM Movie order by mID desc;"
+        query = "select mID from Movie where mID"
+        _, _, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=None,
+            is_ordered=False
+        ).attempt(query)
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, False)
+
+    def test_update_statements(self):
+        """
+        Test statements which modify the table
+        """
+        verify_query = "SELECT * FROM Movie where mID = 1"
+        answer_query = "insert into Movie values(1, 'Movie', 2000, 'Director')"
+        query = """
+        update Movie
+        set mID=1, title='Movie', year=2000, director='Director'
+        where mID=101;
+        """
+
+        submission_result, answer_result, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=verify_query,
+            is_ordered=False
+        ).attempt(query)
+
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, True)
+        self.assertEqual(submission_result, answer_result)
+        self.assertEqual(len(submission_result), 1)
+
+    def test_multiple_statements(self):
+        """
+        Test queries with multiple statements in them
+        """
+        verify_query = "select * from Movie where mID < 10"
+        answer_query = """
+        insert into Movie values(1, 'Movie', 2000, 'Director');
+        insert into Movie values(2, 'Movie 2', 2000, 'Director 2');
+        """
+        query = """
+        update Movie
+        set mID=1, title='Movie', year=2000, director='Director'
+        where mID=101;
+        insert into Movie values(2, 'Movie 2', 2000, 'Director 2');
+        """
+
+        submission_result, answer_result, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=verify_query,
+            is_ordered=False
+        ).attempt(query)
+
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, True)
+        self.assertEqual(submission_result, answer_result)
+        self.assertEqual(len(submission_result), 2)
+
+        verify_query = """
+        insert into Movie values(3, 'Movie', 2000, 'Director 3');
+        SELECT * FROM Movie where mID < 10;
+        """
+        submission_result, answer_result, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=verify_query,
+            is_ordered=False
+        ).attempt(query)
+
+        self.assertNotEqual(error, None)
+
+    def test_pre_verification(self):
+        """
+        Test that modification_query is executed before checking outputs
+        """
+        answer_query = """
+        create trigger change1
+        after insert on Movie
+        for each row
+        when (new.year > 1980 and new.year < 1990)
+          begin update Movie
+            set title="80s movie" where mID=new.mID; end;
+
+        create trigger change2
+        after insert on Movie
+        for each row
+        when (new.year is NULL)
+          begin update Movie
+            set director=NULL where mID=new.mID; end;
+        """
+        query = answer_query
+        modification_query = """
+        insert into Movie values (1, "E.T.", 1982, "Steven Spielberg");
+        insert into Movie values (2, null, 1992, "David Fincher");
+        """
+        verify_query = """
+        select * from Movie
+        where title like '80s %' or title IS NULL
+        """
+
+        submission_result, answer_result, error, comparison = SqlProblem(
+            answer_query=answer_query,
+            database=self.database,
+            verify_query=verify_query,
+            modification_query=modification_query,
+            is_ordered=False
+        ).attempt(query)
+        self.assertEqual(error, None)
+        self.assertEqual(comparison, True)
+        self.assertEqual(submission_result, answer_result)
+        self.assertEqual(submission_result, [
+            (1, '80s movie', 1982, 'Steven Spielberg'),
+            (2, None, 1992, 'David Fincher')
+        ])
+
+    def test_error_with_invalid_answer_query(self):
+        """
+        Verify that a syntax error is displayed when answer_query
+        contains errors.
+        """
+        _, _, error, _ = SqlProblem(
+            answer_query="Not a query;",
+            database=self.database,
+            verify_query=None,
+            is_ordered=True
+        ).attempt("SELECT * FROM Movie;")
+        self.assertIn("Problem setup incorrectly", error)
+        self.assertIn("syntax error", error)
+
+    def test_error_with_invalid_verify_query(self):
+        """
+        Verify that a syntax error is displayed when verify_query
+        contains errors.
+        """
+        _, _, error, _ = SqlProblem(
+            answer_query="",
+            database=self.database,
+            verify_query="Not a query;",
+            is_ordered=True
+        ).attempt("Not a SQL Query;")
+        self.assertIn("Problem setup incorrectly", error)
+        self.assertIn("verify_query", error)
+        self.assertIn("syntax error", error)
+
+    def test_error_with_invalid_modification_query(self):
+        """
+        Verify that a syntax error is displayed when modification_query
+        contains errors.
+        """
+        _, _, error, _ = SqlProblem(
+            answer_query="",
+            database=self.database,
+            verify_query="SELECT;",
+            modification_query="Not a query;",
+            is_ordered=True
+        ).attempt("Not a SQL Query;")
+        self.assertIn("Problem setup incorrectly", error)
+        self.assertIn("modification_query", error)
+        self.assertIn("syntax error", error)
+
+    def test_error_with_invalid_submitted_query(self):
+        """
+        Verify that a syntax error is displayed when the submitted answer
+        contains errors.
+        """
+        _, _, error, _ = SqlProblem(
+            answer_query="SELECT * FROM Movie;",
+            database=self.database,
+            verify_query=None,
+            is_ordered=True
+        ).attempt("Not a SQL Query;")
+        self.assertNotIn("Problem setup incorrectly", error)
+        self.assertIn("syntax error", error)
+
+    def test_error_with_valid_verify_query(self):
+        """
+        Verify that errors are displayed when the verification query is
+        syntactically valid but errors out due to different error.
+        """
+        _, _, error, _ = SqlProblem(
+            answer_query="",
+            database=self.database,
+            verify_query="select * from Movie",
+            is_ordered=True
+        ).attempt("alter table Movie rename to Movie2")
+        self.assertNotIn("Problem setup incorrectly", error)
+        self.assertIn("verify_query", error)
+        self.assertIn("no such table", error)

--- a/sql_grader/xblocks.py
+++ b/sql_grader/xblocks.py
@@ -68,5 +68,6 @@ class SqlGrader(
             'result': actual,
             'expected': expected,
             'verify': self.verify_query,
+            'modification': self.modification_query,
             'error': error,
         }


### PR DESCRIPTION
This PR adds support for multiple statements in the XBlock, and improves error handling for failed queries. It also updates the XBlock version to 0.2

Adding that functionality in `answer_query` was a rather simple change - executing the query with `executescript()` instead of `execute()` (we actually try execute first, due to a caveat mentioned below).

`executescript()` in Python's sqlite library doesn't return any result back, hence any `SELECT` statements which are a part of `executescript()` are in-effect ignored. This does makes sense as multiple queries are often meant to perform updates only (no result returned), whereas multiple `SELECT` statements rarely makes sense.

So, if `verify_query` is being used and it's expecting multiple statements (eg - for testing triggers), then such queries need to be broken up into two parts (as done in this PR):
- `modification_query` is a newly added parameter - and it will contain all modification statements to be performed after executing `answer_query` or the user's queries
- `verify_query` will just contain a single SQL query, and returns a result

**JIRA tickets**: [OSPR-5080](https://openedx.atlassian.net/browse/OSPR-5080), [Opencraft/SE-3218](https://tasks.opencraft.com/browse/SE-3218)

**Sandbox URL**: 

_Executing SQL queries might seem slow in the resource-limited sandbox, which is a pre-existing condition, due to the use of [codejail](https://github.com/edx/codejail). There has been no significantly increase in execution time as a result of this PR._

- [Studio](https://studio.sql-grader-sandbox.opencraft.hosting/container/block-v1:opencraft+tc101+2020_t1+type@vertical+block@4b04b02e265145928bbd4f85affc4355)
- [LMS](https://sql-grader-sandbox.opencraft.hosting/courses/course-v1:opencraft+tc101+2020_t1/courseware/4d25249819be4648b57f6960c29969d2/88903eaf41a74515842adfebc5da34d1/1?activate_block_id=block-v1%3Aopencraft%2Btc101%2B2020_t1%2Btype%40vertical%2Bblock%404b04b02e265145928bbd4f85affc4355)

**Testing instructions**:

1. Install this XBlock in the LMS container by cloning the repo in `/edx/src`, and running `pip install -e .` in the repo
2. Run `make test` inside the repo
3. Repeat the above two steps in studio to install the XBlock there
4. To enable the block in a course, add "sql_grader" in "Course > Settings > Advanced Settings > Advanced Module List" inside the unit editor in studio
5. Add an exercise by clicking Advanced > SQL Problem at the bottom of the unit in studio
6. Play with different configurations and answers with the block in a course

**Reviewers**
- [ ] @clemente
- [ ] edX reviewer[s] TBD