### PR TITLE
build: add CODEOWNERS; edx/community-engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @edx/community-engineering


### PR DESCRIPTION
Background\n==========\nAs part of our Squad-based ownership, we should stay on top of what\nhappens in these repositories. However, due to the number of\nrepositories (and subsequently pull requests) across the edX ecosystem,\nit is challenging to stay on top of notifications, separating the\n'signal' from the 'noise'. Email filters can go a long way to taming\nInbox notifications, but this is manual and requires maintenance as\nSquad ownership changes. It also fails to account for Github-specific behavior.\n\nProposal\n========\nBy leveraging Github support for `CODEOWNERS` files [1],\nwe can ensure that our team is at least CCed explicitly, here,\nin the form a requested review. This request is just that, a request,\nnot a requirement; we are not enacting any new merge requirements\nat this time.\n\n- [1] https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners\n