### PR TITLE
docs: update README with migration notice to xblocks-extra

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,24 @@
-.. image:: https://img.shields.io/badge/status-deprecated-red
+.. image:: https://img.shields.io/badge/status-archived-red
    :alt: Status
+
+⚠️ Repository Migration Notice ⚠️
+***********************************
 
 .. warning::
 
-   **This Repository is Deprecated**
+   This ``xblock-sql-grader`` repository is being archived. The SQL Grader XBlock
+   is moving to the `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ repository,
+   which consolidates optional add-on XBlocks for the Open edX platform.
 
-   This repository is no longer maintained.
+   The migration is being completed through:
+   `openedx/xblocks-extra#18 — feat: add SQL Grader XBlock <https://github.com/openedx/xblocks-extra/pull/18>`_
 
-   The SQL Grader XBlock has been moved to:
-   https://github.com/openedx/xblocks-extra
+   **Archival:** This repository will become read-only once the migration is complete.
+   No further updates or changes will be accepted here.
 
-   Please use the new repository for all future work.
+   Please use `xblocks-extra <https://github.com/openedx/xblocks-extra>`_ for all future work.
+   If you have any questions or concerns, please open an issue on the
+   `xblocks-extra issue tracker <https://github.com/openedx/xblocks-extra/issues>`_.
 
 
 SQL Grader XBlock

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,18 @@
+.. image:: https://img.shields.io/badge/status-deprecated-red
+   :alt: Status
+
+.. warning::
+
+   **This Repository is Deprecated**
+
+   This repository is no longer maintained.
+
+   The SQL Grader XBlock has been moved to:
+   https://github.com/openedx/xblocks-extra
+
+   Please use the new repository for all future work.
+
+
 SQL Grader XBlock
 =================
 


### PR DESCRIPTION
Updates the deprecation notice to clarify that this repository is being archived and the block is migrating to https://github.com/openedx/xblocks-extra/pull/18. Points users to the new repo for all future work.